### PR TITLE
connected frontdesk and accesspage to endpoint

### DIFF
--- a/src/pages/admit.jsx
+++ b/src/pages/admit.jsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from "react-router-dom"
 import { useDispatch, useSelector } from "react-redux"
 import "../styles/access.css"
 import { fetchSingleEvent } from "../redux/slices/eventSlice"
+import { markAttendee } from "../redux/slices/attendeeSlice"
 import { CalendarDays, Clock, AlertCircle, Mail, Key, Eye, MapPin, Tag, Calendar, Users } from "lucide-react"
 import QuickRegistrationForm from "../components/forms/QuickRegistrationForm"
 
@@ -15,6 +16,8 @@ const Admit = () => {
 
   // Destructure state from useSelector
   const { singleEvent: event, loading, error } = useSelector((state) => state.events)
+  // Add attendee state from reducer
+  const { loading: attendeeLoading, error: attendeeError, success: attendeeSuccess } = useSelector((state) => state.attendee)
 
   const [accessMode, setAccessMode] = useState("otp")
   const [input, setInput] = useState(["", "", "", "", "", ""]) // Updated to 6 digits
@@ -28,6 +31,14 @@ const Admit = () => {
       dispatch(fetchSingleEvent(unique_id))
     }
   }, [unique_id, dispatch])
+
+  // Update when attendance marking is successful
+  useEffect(() => {
+    if (attendeeSuccess) {
+      // Navigate to stream view page with event ID
+      navigate(`/stream/${unique_id}`)
+    }
+  }, [attendeeSuccess, navigate, unique_id])
 
   useEffect(() => {
     if (event) {
@@ -80,11 +91,21 @@ const Admit = () => {
 
       // Convert OTP to lowercase before sending
       const accessValue = accessMode === "otp" ? input.join("").toLowerCase() : input.join("")
-
-      console.log("Proceeding to event stream with:", accessValue)
-
-      // Navigate to stream view page with event ID
-      navigate(`/stream/${unique_id}`)
+      
+      // Create payload based on access mode
+      const payload = {
+        event_id: event.id,
+        mode: "offline" // Using offline mode for admit page
+      }
+      
+      if (accessMode === "otp") {
+        payload.otp = accessValue
+      } else {
+        payload.email = accessValue
+      }
+      
+      // Dispatch the markAttendee action
+      dispatch(markAttendee(payload))
     }
   }
 
@@ -276,9 +297,26 @@ const Admit = () => {
               </p>
             )}
 
-            <button onClick={handleValidation} className="watch-btn">
-              <Eye size={18} style={{ marginRight: "8px" }} />
-              {eventStatus === "upcoming" ? "Watch Event" : eventStatus === "ongoing" ? "Join Live" : "Watch Recording"}
+            {attendeeError && (
+              <p className="error-msg">
+                <AlertCircle size={16} style={{ marginRight: "8px" }} />
+                {attendeeError}
+              </p>
+            )}
+
+            <button 
+              onClick={handleValidation} 
+              className="watch-btn"
+              disabled={attendeeLoading}
+            >
+              {attendeeLoading ? (
+                <span>Processing...</span>
+              ) : (
+                <>
+                  <Eye size={18} style={{ marginRight: "8px" }} />
+                  {eventStatus === "upcoming" ? "Watch Event" : eventStatus === "ongoing" ? "Join Live" : "Watch Recording"}
+                </>
+              )}
             </button>
 
             <p onClick={toggleMode} className="toggle-mode">

--- a/src/pages/eventAccess.jsx
+++ b/src/pages/eventAccess.jsx
@@ -5,6 +5,7 @@ import { useParams, useNavigate } from "react-router-dom"
 import { useDispatch, useSelector } from "react-redux"
 import "../styles/access.css"
 import { fetchSingleEvent } from "../redux/slices/eventSlice"
+import { markAttendee } from "../redux/slices/attendeeSlice"
 import { CalendarDays, Clock, AlertCircle, Mail, Key, Eye, MapPin, Tag, Calendar, Users } from "lucide-react"
 import QuickRegistrationForm from "../components/forms/QuickRegistrationForm"
 
@@ -15,6 +16,9 @@ const GuestEventAccess = () => {
 
   // Destructure state from useSelector
   const { singleEvent: event, loading, error } = useSelector((state) => state.events)
+
+  // Add new state from attendee reducer
+  const { loading: attendeeLoading, error: attendeeError, success: attendeeSuccess } = useSelector((state) => state.attendee)
 
   const [accessMode, setAccessMode] = useState("otp")
   const [input, setInput] = useState(["", "", "", "", "", ""]) // Updated to 6 digits
@@ -64,6 +68,14 @@ const GuestEventAccess = () => {
     }
   }, [event])
 
+  // Update when attendance marking is successful
+  useEffect(() => {
+    if (attendeeSuccess) {
+      // Navigate to stream view page with event ID
+      navigate(`/stream/${unique_id}`)
+    }
+  }, [attendeeSuccess, navigate, unique_id])
+
   const toggleMode = () => {
     setAccessMode((prev) => (prev === "otp" ? "email" : "otp"))
     setInput(accessMode === "otp" ? [""] : ["", "", "", "", "", ""])
@@ -80,11 +92,21 @@ const GuestEventAccess = () => {
 
       // Convert OTP to lowercase before sending
       const accessValue = accessMode === "otp" ? input.join("").toLowerCase() : input.join("")
-
-      console.log("Proceeding to event stream with:", accessValue)
-
-      // Navigate to stream view page with event ID
-      navigate(`/stream/${unique_id}`)
+      
+      // Create payload based on access mode
+      const payload = {
+        event_id: event.id,
+        mode: "online"
+      }
+      
+      if (accessMode === "otp") {
+        payload.otp = accessValue
+      } else {
+        payload.email = accessValue
+      }
+      
+      // Dispatch the markAttendee action
+      dispatch(markAttendee(payload))
     }
   }
 
@@ -277,9 +299,19 @@ const GuestEventAccess = () => {
               </p>
             )}
 
-            <button onClick={handleValidation} className="watch-btn">
-              <Eye size={18} style={{ marginRight: "8px" }} />
-              {eventStatus === "upcoming" ? "Watch Event" : eventStatus === "ongoing" ? "Join Live" : "Watch Recording"}
+            <button 
+              onClick={handleValidation} 
+              className="watch-btn"
+              disabled={attendeeLoading}
+            >
+              {attendeeLoading ? (
+                <span>Processing...</span>
+              ) : (
+                <>
+                  <Eye size={18} style={{ marginRight: "8px" }} />
+                  {eventStatus === "upcoming" ? "Watch Event" : eventStatus === "ongoing" ? "Join Live" : "Watch Recording"}
+                </>
+              )}
             </button>
 
             <p onClick={toggleMode} className="toggle-mode">

--- a/src/redux/slices/attendeeSlice.js
+++ b/src/redux/slices/attendeeSlice.js
@@ -1,0 +1,58 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit"
+import axiosInstance from "../../config"
+
+export const markAttendee = createAsyncThunk(
+  "attendee/markAttendee",
+  async ({ event_id, mode, email, otp }, { rejectWithValue }) => {
+    try {
+      const payload = {
+        event_id,
+        mode
+      }
+      
+      // Add optional parameters if provided
+      if (email) payload.email = email
+      if (otp) payload.otp = otp
+      
+      const res = await axiosInstance.patch("/api/v1/mark_attendee", payload)
+      return res.data
+    } catch (error) {
+      return rejectWithValue(error.response?.data?.message || "Failed to mark attendance")
+    }
+  }
+)
+
+const attendeeSlice = createSlice({
+  name: "attendee",
+  initialState: {
+    loading: false,
+    error: null,
+    success: false
+  },
+  reducers: {
+    resetAttendanceStatus: (state) => {
+      state.loading = false
+      state.error = null
+      state.success = false
+    }
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(markAttendee.pending, (state) => {
+        state.loading = true
+        state.error = null
+        state.success = false
+      })
+      .addCase(markAttendee.fulfilled, (state) => {
+        state.loading = false
+        state.success = true
+      })
+      .addCase(markAttendee.rejected, (state, action) => {
+        state.loading = false
+        state.error = action.payload || action.error.message
+      })
+  }
+})
+
+export const { resetAttendanceStatus } = attendeeSlice.actions
+export default attendeeSlice.reducer

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
 import eventsReducer from './slices/eventSlice';
-import frontdeskReducer from './slices/frontdeskSlice'
+import frontdeskReducer from './slices/frontdeskSlice';
+import attendeeReducer from './slices/attendeeSlice';
 
 export const store = configureStore({
   reducer: {
     events: eventsReducer,
     frontdesk: frontdeskReducer,
+    attendee: attendeeReducer,
   },
 });


### PR DESCRIPTION

This PR adds the ability for users to mark their attendance for events through both online and offline modes. It implements an attendance tracking system using Redux that allows guests to watch recordings based on either OTP or email validation.

## Changes

### New features
- Created a new Redux slice (`attendeeSlice.js`) to handle attendance marking API calls
- Added support for marking attendance through both offline (in-person) and online modes
- Implemented authentication via 6-digit OTP or email address
- Added loading states, error handling, and success feedback for attendance marking 
- Automatic redirect to stream view after successful attendance validation

### Implementation details
- Created `markAttendee` async thunk that connects to the `/api/v1/mark_attendee` endpoint
- Added offline mode in the admit.jsx page for in-person check-ins
- Added online mode in the `eventAccess.jsx` page for remote attendees
- Implemented responsive UI elements showing loading states during API calls
- Added error messages for failed attendance marking attempts
- OTP validation with auto-focusing between input fields for better user experience
